### PR TITLE
feat: complete multimodal image pipeline for tool results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**yoagent** is a Rust library (crate) for building AI coding agents. It provides a core agent loop, multi-provider LLM streaming, built-in tools, MCP integration, and context management. Published to crates.io as `yoagent`.
+
+## Build & Development Commands
+
+```bash
+cargo build                          # Build the library
+cargo test                           # Run all unit tests
+cargo test <test_name>               # Run a single test by name
+cargo test --test agent_test         # Run a specific test file
+cargo fmt                            # Auto-format code
+cargo fmt -- --check                 # Check formatting (CI uses this)
+cargo clippy --all-targets           # Lint (CI runs with -Dwarnings)
+cargo run --example cli              # Run the interactive CLI example
+cargo run --example basic            # Run the minimal example
+```
+
+CI (`RUSTFLAGS="-Dwarnings"`) treats all clippy warnings as errors. Integration tests in `tests/integration_anthropic.rs` require a live API key and are skipped by default.
+
+## Architecture
+
+### Core Loop Pattern
+
+The central abstraction is a **stateless agent loop** (`agent_loop.rs`) driven by two traits:
+
+- **`StreamProvider`** (`provider/traits.rs`) — streams LLM responses via SSE into an mpsc channel, returning a complete `Message`
+- **`AgentTool`** (`types.rs`) — defines tool name/schema/execution; the primary extension point for custom tools
+
+The loop: stream assistant response → extract tool calls → execute tools (parallel by default) → append results → repeat until `StopReason::Stop` with no follow-ups.
+
+`agent_loop` and `agent_loop_continue` are **free functions**, not methods. The `Agent` struct (`agent.rs`) is an optional stateful wrapper that manages message history, tool registry, steering/follow-up queues, and provider selection.
+
+### Provider System
+
+7 provider implementations behind `StreamProvider`, dispatched by `ApiProtocol` enum via `ProviderRegistry`:
+
+| Protocol | File | Covers |
+|----------|------|--------|
+| `Anthropic` | `anthropic.rs` | Claude models |
+| `OpenAiCompat` | `openai_compat.rs` | OpenAI, Groq, Together, DeepSeek, Fireworks, Mistral, xAI, etc. (15+) |
+| `OpenAiResponses` | `openai_responses.rs` | OpenAI Responses API |
+| `AzureOpenAi` | `azure_openai.rs` | Azure OpenAI |
+| `Google` | `google.rs` | Gemini |
+| `GoogleVertex` | `google_vertex.rs` | Vertex AI |
+| `Bedrock` | `bedrock.rs` | Amazon Bedrock (ConverseStream) |
+
+`ModelConfig` + `OpenAiCompat` flags handle per-provider quirks (auth style, reasoning format, max_tokens field name, etc.).
+
+### Key Types
+
+- **`Content`** — enum: `Text`, `Image`, `Thinking`, `ToolCall`
+- **`Message`** — enum: `User`, `Assistant`, `ToolResult` — each variant carries its own fields
+- **`AgentMessage`** — `Llm(Message)` | `Extension { role, data }` — extension messages don't enter LLM context
+- **`AgentEvent`** — full event stream emitted to callers: `AgentStart`, `TurnStart`, `MessageStart/Update/End`, `ToolExecutionStart/Update/End`, `TurnEnd`, `AgentEnd`
+- **`StopReason`** — `Stop`, `Length`, `ToolUse`, `Error`, `Aborted`
+
+### Context Management (`context.rs`)
+
+- **`ContextTracker`** — hybrid real-usage + estimation for token tracking
+- **`compact_messages()`** — tiered compaction: Level 1 (truncate tool outputs) → Level 2 (summarize old turns) → Level 3 (drop middle turns)
+- **`ExecutionLimits`/`ExecutionTracker`** — max turns (50), max tokens (1M), max duration (10 min)
+
+### Tool Execution (`agent_loop.rs`)
+
+`ToolExecutionStrategy` controls concurrency:
+- `Parallel` (default) — `futures::join_all` for all tool calls
+- `Sequential` — one at a time, checks steering queue between each
+- `Batched { size }` — concurrent within batch, steering check between batches
+
+### MCP Integration (`mcp/`)
+
+`McpClient` communicates via `McpTransport` trait (stdio or HTTP). `McpToolAdapter` wraps MCP tools to implement `AgentTool`, making them transparent to the agent loop. Added via `Agent::with_mcp_server_stdio()` / `with_mcp_server_http()`.
+
+### Testing
+
+All unit tests use `MockProvider` (`provider/mock.rs`) to simulate LLM responses without network. Test files are in `tests/` — `agent_test.rs`, `agent_loop_test.rs`, `tools_test.rs`. Follow the existing pattern of constructing a `MockProvider` with predetermined responses.
+
+## Key Design Conventions
+
+- Context overflow detection is centralized in `OVERFLOW_PHRASES` (`provider/traits.rs`) covering 15+ provider-specific error strings; both HTTP errors and SSE-embedded errors are classified
+- Tools return stdout/stderr even on failure so the LLM can self-correct
+- Retry logic (`retry.rs`) uses exponential backoff with ±20% jitter; only retries `RateLimited` and `Network` errors
+- The `skills.rs` module loads `<name>/SKILL.md` files with YAML frontmatter per the AgentSkills standard

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 reqwest-eventsource = "0.6"
 futures = "0.3"
 rand = "0.10.0"
+base64 = "0.22"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/src/provider/azure_openai.rs
+++ b/src/provider/azure_openai.rs
@@ -277,17 +277,36 @@ fn build_azure_request_body(config: &StreamConfig) -> serde_json::Value {
                 content,
                 ..
             } => {
-                let text = content
-                    .iter()
-                    .find_map(|c| match c {
-                        Content::Text { text } => Some(text.clone()),
-                        _ => None,
-                    })
-                    .unwrap_or_default();
+                let output_val = if content.iter().any(|c| matches!(c, Content::Image { .. })) {
+                    let parts: Vec<serde_json::Value> = content
+                        .iter()
+                        .filter_map(|c| match c {
+                            Content::Text { text } => Some(serde_json::json!({
+                                "type": "input_text",
+                                "text": text,
+                            })),
+                            Content::Image { data, mime_type } => Some(serde_json::json!({
+                                "type": "input_image",
+                                "image_url": format!("data:{};base64,{}", mime_type, data),
+                            })),
+                            _ => None,
+                        })
+                        .collect();
+                    serde_json::json!(parts)
+                } else {
+                    let text = content
+                        .iter()
+                        .find_map(|c| match c {
+                            Content::Text { text } => Some(text.clone()),
+                            _ => None,
+                        })
+                        .unwrap_or_default();
+                    serde_json::json!(text)
+                };
                 input.push(serde_json::json!({
                     "type": "function_call_output",
                     "call_id": tool_call_id,
-                    "output": text,
+                    "output": output_val,
                 }));
             }
         }

--- a/src/provider/google.rs
+++ b/src/provider/google.rs
@@ -220,14 +220,26 @@ fn build_request_body(config: &StreamConfig) -> serde_json::Value {
                         _ => None,
                     })
                     .unwrap_or_default();
+
+                let mut parts = vec![serde_json::json!({
+                    "functionResponse": {
+                        "name": tool_name,
+                        "response": {"result": text},
+                    }
+                })];
+
+                // Append image parts if present
+                for c in content {
+                    if let Content::Image { data, mime_type } = c {
+                        parts.push(serde_json::json!({
+                            "inlineData": {"mimeType": mime_type, "data": data},
+                        }));
+                    }
+                }
+
                 contents.push(serde_json::json!({
                     "role": "user",
-                    "parts": [{
-                        "functionResponse": {
-                            "name": tool_name,
-                            "response": {"result": text},
-                        }
-                    }],
+                    "parts": parts,
                 }));
             }
         }

--- a/src/provider/google_vertex.rs
+++ b/src/provider/google_vertex.rs
@@ -317,9 +317,22 @@ fn build_vertex_request_body(config: &StreamConfig) -> serde_json::Value {
                         _ => None,
                     })
                     .unwrap_or_default();
+
+                let mut parts = vec![serde_json::json!({
+                    "functionResponse": {"name": tool_name, "response": {"result": text}}
+                })];
+
+                for c in content {
+                    if let Content::Image { data, mime_type } = c {
+                        parts.push(serde_json::json!({
+                            "inlineData": {"mimeType": mime_type, "data": data},
+                        }));
+                    }
+                }
+
                 contents.push(serde_json::json!({
                     "role": "user",
-                    "parts": [{"functionResponse": {"name": tool_name, "response": {"result": text}}}],
+                    "parts": parts,
                 }));
             }
         }

--- a/tests/tools_test.rs
+++ b/tests/tools_test.rs
@@ -1,5 +1,6 @@
 //! Tests for built-in tools.
 
+use base64::Engine;
 use tokio_util::sync::CancellationToken;
 use yoagent::tools::edit::EditFileTool;
 use yoagent::tools::list::ListFilesTool;
@@ -390,4 +391,103 @@ async fn test_default_tools_complete() {
     assert!(names.contains(&"bash"));
     assert!(names.contains(&"edit_file"));
     assert!(names.contains(&"list_files"));
+}
+
+// --- Image support tests ---
+
+#[tokio::test]
+async fn test_read_image_file() {
+    // Minimal valid PNG (1x1 pixel, transparent)
+    let png_bytes: Vec<u8> = vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // 1x1
+        0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xDE, // 8-bit RGB
+        0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, // IDAT chunk
+        0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC,
+        0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, // IEND chunk
+        0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    let tmp = std::env::temp_dir().join("yoagent-test-image.png");
+    std::fs::write(&tmp, &png_bytes).unwrap();
+
+    let tool = ReadFileTool::new();
+    let result = tool
+        .execute(
+            "t1",
+            serde_json::json!({"path": tmp.to_str().unwrap()}),
+            CancellationToken::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    match &result.content[0] {
+        Content::Image { data, mime_type } => {
+            assert_eq!(mime_type, "image/png");
+            assert!(!data.is_empty());
+            // Verify round-trip: decode should match original bytes
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(data)
+                .unwrap();
+            assert_eq!(decoded, png_bytes);
+        }
+        _ => panic!("expected Content::Image"),
+    }
+
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
+async fn test_read_jpeg_file() {
+    let tmp = std::env::temp_dir().join("yoagent-test-image.jpg");
+    std::fs::write(&tmp, b"fake-jpeg-data").unwrap();
+
+    let tool = ReadFileTool::new();
+    let result = tool
+        .execute(
+            "t1",
+            serde_json::json!({"path": tmp.to_str().unwrap()}),
+            CancellationToken::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    match &result.content[0] {
+        Content::Image { mime_type, .. } => {
+            assert_eq!(mime_type, "image/jpeg");
+        }
+        _ => panic!("expected Content::Image for .jpg"),
+    }
+
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
+async fn test_read_text_file_unchanged() {
+    // Non-image files should still return Content::Text
+    let tmp = std::env::temp_dir().join("yoagent-test-notimage.txt");
+    std::fs::write(&tmp, "just text").unwrap();
+
+    let tool = ReadFileTool::new();
+    let result = tool
+        .execute(
+            "t1",
+            serde_json::json!({"path": tmp.to_str().unwrap()}),
+            CancellationToken::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    match &result.content[0] {
+        Content::Text { text } => {
+            assert!(text.contains("just text"));
+        }
+        _ => panic!("expected Content::Text for .txt file"),
+    }
+
+    let _ = std::fs::remove_file(tmp);
 }


### PR DESCRIPTION
## Summary

- **ReadFileTool** now detects image files (jpg, jpeg, png, webp, gif, bmp) and returns base64-encoded `Content::Image` with a 20MB size limit
- **All 7 providers** fixed to serialize `Content::Image` in `Message::ToolResult` (previously silently dropped). Uses conditional format: array when images present, plain string for text-only (max backward compat)
- **Token estimation** improved from flat 1000 to base64-length-based heuristic clamped to 85–16000 tokens
- Added **CLAUDE.md** for repository guidance

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets` with `-Dwarnings` passes
- [x] All 114 tests pass (72 unit + 15 agent_loop + 4 agent + 20 tools + 3 doc-tests)
- [x] New tests: ReadFileTool PNG/JPEG/text-fallback, Anthropic + OpenAI compat ToolResult image serialization
- [ ] Manual: `cargo run --example cli` → ask agent to read an image file with a vision-capable model

🤖 Generated with [Claude Code](https://claude.com/claude-code)