### PR TITLE
feat: improve CLI example — fix UTF-8 panic, add error display, polish UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ ANTHROPIC_API_KEY=sk-... cargo run --example cli
 ANTHROPIC_API_KEY=sk-... cargo run --example cli -- --skills ./skills
 ```
 
-A ~230-line interactive coding agent with all built-in tools, skills support, streaming output, and colored tool feedback. Like a baby Claude Code.
+A ~250-line interactive coding agent with all built-in tools, skills support, streaming output, and colored tool feedback. Like a baby Claude Code.
 
 ```
   yoagent cli — mini coding agent


### PR DESCRIPTION
## Summary

- **Fix UTF-8 panic**: `truncate()` used byte slicing (`&s[..max]`) which panics on multi-byte characters (emoji, CJK). Now uses `char_indices()` for safe truncation.
- **Display errors**: `StopReason::Error` messages (API failures, rate limits, network errors) were silently swallowed by the `_ => {}` catch-all. Now shown in red.
- **Use `clear_messages()`**: `/clear` command rebuilt the entire `Agent`, losing runtime config. Now uses the existing `clear_messages()` method.
- **Ctrl+C handling**: Graceful exit with goodbye message instead of raw `^C` output.
- **Accurate line count**: Updated doc comment (~150 → ~250) and README (~230 → ~250) to match actual file length.

## Test plan

- [ ] `cargo fmt -- --check` passes
- [ ] `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` passes
- [ ] `cargo test` — all tests pass
- [ ] `cargo build --examples` — cli compiles cleanly
- [ ] Manual: run `cargo run --example cli`, verify streaming, `/clear`, Ctrl+C

🤖 Generated with [Claude Code](https://claude.com/claude-code)