### PR TITLE
fix: Gemini streaming and function calling

### DIFF
--- a/examples/callbacks.rs
+++ b/examples/callbacks.rs
@@ -19,6 +19,7 @@ async fn main() {
     // Provider: tool call → text response (2-turn conversation)
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "greet".into(),
             arguments: serde_json::json!({"name": "World"}),
         }]),

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -382,6 +382,7 @@ async fn run_loop(
                             id,
                             name,
                             arguments,
+                            ..
                         } => Some((id.clone(), name.clone(), arguments.clone())),
                         _ => None,
                     })

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -96,7 +96,7 @@ impl StreamProvider for AnthropicProvider {
                                             }
                                             AnthropicContentBlock::ToolUse { id, name, .. } => {
                                                 while content.len() <= idx {
-                                                    content.push(Content::ToolCall {
+                                                    content.push(Content::ToolCall { provider_metadata: None,
                                                         id: id.clone(),
                                                         name: name.clone(),
                                                         arguments: serde_json::Value::Object(Default::default()),
@@ -438,6 +438,7 @@ fn content_to_anthropic(content: &[Content]) -> Vec<serde_json::Value> {
                 id,
                 name,
                 arguments,
+                ..
             } => serde_json::json!({
                 "type": "tool_use",
                 "id": id,
@@ -658,6 +659,7 @@ mod tests {
             messages: vec![
                 Message::Assistant {
                     content: vec![Content::ToolCall {
+                        provider_metadata: None,
                         id: "tc-1".into(),
                         name: "read_file".into(),
                         arguments: serde_json::json!({"path": "test.png"}),
@@ -718,6 +720,7 @@ mod tests {
             messages: vec![
                 Message::Assistant {
                     content: vec![Content::ToolCall {
+                        provider_metadata: None,
                         id: "tc-1".into(),
                         name: "bash".into(),
                         arguments: serde_json::json!({"command": "echo hi"}),

--- a/src/provider/azure_openai.rs
+++ b/src/provider/azure_openai.rs
@@ -151,6 +151,7 @@ impl StreamProvider for AzureOpenAiProvider {
             let args = serde_json::from_str(&buf.arguments)
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             content.push(Content::ToolCall {
+                provider_metadata: None,
                 id: buf.id.clone(),
                 name: buf.name.clone(),
                 arguments: args,
@@ -243,6 +244,7 @@ fn build_azure_request_body(config: &StreamConfig) -> serde_json::Value {
                             id,
                             name,
                             arguments,
+                            ..
                         } => {
                             input.push(serde_json::json!({
                                 "type": "function_call",

--- a/src/provider/bedrock.rs
+++ b/src/provider/bedrock.rs
@@ -147,7 +147,7 @@ impl StreamProvider for BedrockProvider {
                                     BedrockEvent::ContentBlockStart { start, .. } => {
                                         if let Some(tool_use) = start.tool_use {
                                             let idx = content.len();
-                                            content.push(Content::ToolCall {
+                                            content.push(Content::ToolCall { provider_metadata: None,
                                                 id: tool_use.tool_use_id.clone(),
                                                 name: tool_use.name.clone(),
                                                 arguments: serde_json::Value::Object(Default::default()),
@@ -315,6 +315,7 @@ fn content_to_bedrock(content: &[Content]) -> Vec<serde_json::Value> {
                 id,
                 name,
                 arguments,
+                ..
             } => Some(serde_json::json!({
                 "toolUse": {"toolUseId": id, "name": name, "input": arguments},
             })),
@@ -432,6 +433,7 @@ mod tests {
                 text: "hello".into(),
             },
             Content::ToolCall {
+                provider_metadata: None,
                 id: "tc-1".into(),
                 name: "bash".into(),
                 arguments: serde_json::json!({"command": "ls"}),

--- a/src/provider/google.rs
+++ b/src/provider/google.rs
@@ -84,14 +84,16 @@ impl StreamProvider for GoogleProvider {
                         Some(Ok(bytes)) => {
                             buffer.push_str(&String::from_utf8_lossy(&bytes));
 
-                            // Process complete SSE events
-                            while let Some(pos) = buffer.find("\n\n") {
+                            // Process complete SSE events (handle both \n\n and \r\n\r\n)
+                            while let Some(pos) = buffer.find("\n\n").or_else(|| buffer.find("\r\n\r\n")) {
+                                let sep_len = if buffer[pos..].starts_with("\r\n\r\n") { 4 } else { 2 };
                                 let event_str = buffer[..pos].to_string();
-                                buffer = buffer[pos + 2..].to_string();
+                                buffer = buffer[pos + sep_len..].to_string();
 
-                                // Parse SSE data line
+                                // Parse SSE data line (strip trailing \r)
                                 let data = event_str
                                     .lines()
+                                    .map(|l| l.trim_end_matches('\r'))
                                     .find(|l| l.starts_with("data: "))
                                     .map(|l| &l[6..])
                                     .unwrap_or("");
@@ -103,7 +105,7 @@ impl StreamProvider for GoogleProvider {
                                 let chunk: GoogleChunk = match serde_json::from_str(data) {
                                     Ok(c) => c,
                                     Err(e) => {
-                                        debug!("Failed to parse Google chunk: {}", e);
+                                        warn!("Failed to parse Google chunk: {}", e);
                                         continue;
                                     }
                                 };
@@ -113,6 +115,10 @@ impl StreamProvider for GoogleProvider {
                                     if let Some(c) = &candidate.content {
                                         for part in &c.parts {
                                             if let Some(text) = &part.text {
+                                                // Skip empty text parts (sent during thinking)
+                                                if text.is_empty() {
+                                                    continue;
+                                                }
                                                 let text_idx = content.iter().position(|c| matches!(c, Content::Text { .. }));
                                                 let idx = match text_idx {
                                                     Some(i) => i,
@@ -130,13 +136,17 @@ impl StreamProvider for GoogleProvider {
                                                 });
                                             }
                                             if let Some(fc) = &part.function_call {
-                                                let id = format!("google-fc-{}", content.len());
+                                                let id = fc.id.clone().unwrap_or_else(|| format!("google-fc-{}", content.len()));
                                                 let args = fc.args.clone().unwrap_or(serde_json::Value::Object(Default::default()));
+                                                let metadata = part.thought_signature.as_ref().map(|sig| {
+                                                    serde_json::json!({"thought_signature": sig})
+                                                });
                                                 let idx = content.len();
                                                 content.push(Content::ToolCall {
                                                     id: id.clone(),
                                                     name: fc.name.clone(),
                                                     arguments: args,
+                                                    provider_metadata: metadata,
                                                 });
                                                 let _ = tx.send(StreamEvent::ToolCallStart {
                                                     content_index: idx,
@@ -149,11 +159,15 @@ impl StreamProvider for GoogleProvider {
                                         }
                                     }
                                     if let Some(reason) = &candidate.finish_reason {
-                                        stop_reason = match reason.as_str() {
-                                            "STOP" => StopReason::Stop,
-                                            "MAX_TOKENS" | "RECITATION" => StopReason::Length,
-                                            _ => StopReason::Stop,
-                                        };
+                                        // Don't override ToolUse -- Gemini returns "STOP"
+                                        // even when it emits function calls
+                                        if stop_reason != StopReason::ToolUse {
+                                            stop_reason = match reason.as_str() {
+                                                "STOP" => StopReason::Stop,
+                                                "MAX_TOKENS" | "RECITATION" => StopReason::Length,
+                                                _ => StopReason::Stop,
+                                            };
+                                        }
                                     }
                                 }
 
@@ -208,7 +222,7 @@ fn build_request_body(config: &StreamConfig) -> serde_json::Value {
                 }));
             }
             Message::ToolResult {
-                tool_call_id: _,
+                tool_call_id,
                 tool_name,
                 content,
                 ..
@@ -221,12 +235,14 @@ fn build_request_body(config: &StreamConfig) -> serde_json::Value {
                     })
                     .unwrap_or_default();
 
-                let mut parts = vec![serde_json::json!({
-                    "functionResponse": {
-                        "name": tool_name,
-                        "response": {"result": text},
-                    }
-                })];
+                let mut fr = serde_json::json!({
+                    "name": tool_name,
+                    "response": {"result": text},
+                });
+                if !tool_call_id.is_empty() && !tool_call_id.starts_with("google-fc-") {
+                    fr["id"] = serde_json::json!(tool_call_id);
+                }
+                let mut parts = vec![serde_json::json!({"functionResponse": fr})];
 
                 // Append image parts if present
                 for c in content {
@@ -296,10 +312,25 @@ fn content_to_google_parts(content: &[Content]) -> Vec<serde_json::Value> {
                 "inlineData": {"mimeType": mime_type, "data": data},
             })),
             Content::ToolCall {
-                name, arguments, ..
-            } => Some(serde_json::json!({
-                "functionCall": {"name": name, "args": arguments},
-            })),
+                id,
+                name,
+                arguments,
+                provider_metadata,
+            } => {
+                let mut fc = serde_json::json!({"name": name, "args": arguments});
+                if !id.is_empty() && !id.starts_with("google-fc-") {
+                    fc["id"] = serde_json::json!(id);
+                }
+                let mut part = serde_json::json!({"functionCall": fc});
+                if let Some(sig) = provider_metadata
+                    .as_ref()
+                    .and_then(|m| m.get("thought_signature"))
+                    .and_then(|v| v.as_str())
+                {
+                    part["thoughtSignature"] = serde_json::json!(sig);
+                }
+                Some(part)
+            }
             Content::Thinking { .. } => None,
         })
         .collect()
@@ -334,6 +365,8 @@ struct GooglePart {
     text: Option<String>,
     #[serde(default, rename = "functionCall")]
     function_call: Option<GoogleFunctionCall>,
+    #[serde(default, rename = "thoughtSignature")]
+    thought_signature: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -341,6 +374,8 @@ struct GoogleFunctionCall {
     name: String,
     #[serde(default)]
     args: Option<serde_json::Value>,
+    #[serde(default)]
+    id: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -413,8 +448,191 @@ mod tests {
             id: "tc-1".into(),
             name: "bash".into(),
             arguments: serde_json::json!({"command": "ls"}),
+            provider_metadata: None,
         }];
         let parts = content_to_google_parts(&content);
         assert_eq!(parts[0]["functionCall"]["name"], "bash");
+    }
+
+    #[test]
+    fn test_parse_chunk_with_function_call_and_thought_signature() {
+        let data = r#"{"candidates": [{"content": {"parts": [{"functionCall": {"name": "bash", "args": {"command": "echo hi"}, "id": "abc123"}, "thoughtSignature": "SIG_DATA"}], "role": "model"}, "finishReason": "STOP", "index": 0}], "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 5, "totalTokenCount": 15}}"#;
+
+        let chunk: GoogleChunk = serde_json::from_str(data).unwrap();
+        let candidates = chunk.candidates.unwrap();
+        assert_eq!(candidates.len(), 1);
+
+        let parts = &candidates[0].content.as_ref().unwrap().parts;
+        assert_eq!(parts.len(), 1);
+
+        let fc = parts[0].function_call.as_ref().unwrap();
+        assert_eq!(fc.name, "bash");
+        assert_eq!(fc.id.as_deref(), Some("abc123"));
+        assert_eq!(fc.args.as_ref().unwrap()["command"], "echo hi");
+
+        assert_eq!(parts[0].thought_signature.as_deref(), Some("SIG_DATA"));
+    }
+
+    #[test]
+    fn test_parse_chunk_with_empty_text() {
+        // Gemini sends empty text parts during thinking -- these should parse fine
+        let data = r#"{"candidates": [{"content": {"parts": [{"text": ""}], "role": "model"}, "index": 0}]}"#;
+
+        let chunk: GoogleChunk = serde_json::from_str(data).unwrap();
+        let candidates = chunk.candidates.unwrap();
+        let parts = &candidates[0].content.as_ref().unwrap().parts;
+        assert_eq!(parts[0].text.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn test_parse_chunk_with_crlf_sse() {
+        // Simulate \r\n line endings from Google's API
+        let raw = "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Blue\"}], \"role\": \"model\"}, \"finishReason\": \"STOP\", \"index\": 0}]}\r\n\r\n";
+
+        // Verify our separator detection works
+        let pos = raw.find("\n\n").or_else(|| raw.find("\r\n\r\n"));
+        assert!(pos.is_some(), "Should find separator");
+        let sep_start = pos.unwrap();
+        let is_crlf = raw[sep_start..].starts_with("\r\n\r\n");
+        assert!(is_crlf, "Should detect \\r\\n\\r\\n separator");
+
+        let event_str = &raw[..sep_start];
+        let data = event_str
+            .lines()
+            .map(|l| l.trim_end_matches('\r'))
+            .find(|l| l.starts_with("data: "))
+            .map(|l| &l[6..])
+            .unwrap();
+
+        let chunk: GoogleChunk = serde_json::from_str(data).unwrap();
+        let candidates = chunk.candidates.unwrap();
+        let text = &candidates[0].content.as_ref().unwrap().parts[0].text;
+        assert_eq!(text.as_deref(), Some("Blue"));
+    }
+
+    #[test]
+    fn test_thought_signature_round_trip() {
+        let content = vec![Content::ToolCall {
+            id: "abc123".into(),
+            name: "bash".into(),
+            arguments: serde_json::json!({"command": "echo hi"}),
+            provider_metadata: Some(serde_json::json!({"thought_signature": "SIG_DATA"})),
+        }];
+
+        let parts = content_to_google_parts(&content);
+        assert_eq!(parts.len(), 1);
+
+        assert_eq!(parts[0]["functionCall"]["name"], "bash");
+        assert_eq!(parts[0]["functionCall"]["id"], "abc123");
+        assert_eq!(parts[0]["functionCall"]["args"]["command"], "echo hi");
+        assert_eq!(parts[0]["thoughtSignature"], "SIG_DATA");
+    }
+
+    #[test]
+    fn test_tool_call_without_thought_signature() {
+        // Synthetic IDs (google-fc-*) should not be sent to Gemini
+        let content = vec![Content::ToolCall {
+            id: "google-fc-0".into(),
+            name: "bash".into(),
+            arguments: serde_json::json!({"command": "ls"}),
+            provider_metadata: None,
+        }];
+
+        let parts = content_to_google_parts(&content);
+        assert!(parts[0]["functionCall"].get("id").is_none());
+        assert!(parts[0].get("thoughtSignature").is_none());
+    }
+
+    #[test]
+    fn test_function_response_includes_id() {
+        let config = StreamConfig {
+            model: "gemini-2.5-flash".into(),
+            system_prompt: "".into(),
+            messages: vec![
+                Message::Assistant {
+                    content: vec![Content::ToolCall {
+                        id: "abc123".into(),
+                        name: "bash".into(),
+                        arguments: serde_json::json!({"command": "echo hi"}),
+                        provider_metadata: None,
+                    }],
+                    stop_reason: StopReason::ToolUse,
+                    model: "test".into(),
+                    provider: "test".into(),
+                    usage: Usage::default(),
+                    timestamp: 0,
+                    error_message: None,
+                },
+                Message::ToolResult {
+                    tool_call_id: "abc123".into(),
+                    tool_name: "bash".into(),
+                    content: vec![Content::Text { text: "hi".into() }],
+                    is_error: false,
+                    timestamp: 0,
+                },
+            ],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Off,
+            api_key: "test".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: None,
+            cache_config: CacheConfig::default(),
+        };
+
+        let body = build_request_body(&config);
+        let msgs = body["contents"].as_array().unwrap();
+        let tool_result = &msgs[1]["parts"][0]["functionResponse"];
+        assert_eq!(tool_result["name"], "bash");
+        assert_eq!(tool_result["id"], "abc123");
+        assert_eq!(tool_result["response"]["result"], "hi");
+    }
+
+    #[test]
+    fn test_function_response_synthetic_id_omitted() {
+        let config = StreamConfig {
+            model: "gemini-2.5-flash".into(),
+            system_prompt: "".into(),
+            messages: vec![
+                Message::Assistant {
+                    content: vec![Content::ToolCall {
+                        id: "google-fc-0".into(),
+                        name: "bash".into(),
+                        arguments: serde_json::json!({"command": "ls"}),
+                        provider_metadata: None,
+                    }],
+                    stop_reason: StopReason::ToolUse,
+                    model: "test".into(),
+                    provider: "test".into(),
+                    usage: Usage::default(),
+                    timestamp: 0,
+                    error_message: None,
+                },
+                Message::ToolResult {
+                    tool_call_id: "google-fc-0".into(),
+                    tool_name: "bash".into(),
+                    content: vec![Content::Text {
+                        text: "output".into(),
+                    }],
+                    is_error: false,
+                    timestamp: 0,
+                },
+            ],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Off,
+            api_key: "test".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: None,
+            cache_config: CacheConfig::default(),
+        };
+
+        let body = build_request_body(&config);
+        let msgs = body["contents"].as_array().unwrap();
+        let tool_result = &msgs[1]["parts"][0]["functionResponse"];
+        assert!(
+            tool_result.get("id").is_none(),
+            "Synthetic ID should not be included"
+        );
     }
 }

--- a/src/provider/google_vertex.rs
+++ b/src/provider/google_vertex.rs
@@ -220,7 +220,7 @@ async fn parse_google_sse_response(
                                             let id = format!("vertex-fc-{}", content.len());
                                             let args = fc.args.unwrap_or(serde_json::Value::Object(Default::default()));
                                             let idx = content.len();
-                                            content.push(Content::ToolCall {
+                                            content.push(Content::ToolCall { provider_metadata: None,
                                                 id: id.clone(),
                                                 name: fc.name.clone(),
                                                 arguments: args,

--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -16,6 +16,8 @@ pub enum MockResponse {
 pub struct MockToolCall {
     pub name: String,
     pub arguments: serde_json::Value,
+    #[allow(dead_code)]
+    pub provider_metadata: Option<serde_json::Value>,
 }
 
 /// Mock LLM provider for tests. Supply a sequence of responses.
@@ -98,10 +100,10 @@ impl StreamProvider for MockProvider {
                         });
                         let _ = tx.send(StreamEvent::ToolCallEnd { content_index: i });
                         Content::ToolCall {
-                            provider_metadata: None,
                             id,
                             name: call.name.clone(),
                             arguments: call.arguments.clone(),
+                            provider_metadata: call.provider_metadata.clone(),
                         }
                     })
                     .collect();

--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -98,6 +98,7 @@ impl StreamProvider for MockProvider {
                         });
                         let _ = tx.send(StreamEvent::ToolCallEnd { content_index: i });
                         Content::ToolCall {
+                            provider_metadata: None,
                             id,
                             name: call.name.clone(),
                             arguments: call.arguments.clone(),

--- a/src/provider/openai_compat.rs
+++ b/src/provider/openai_compat.rs
@@ -196,6 +196,7 @@ impl StreamProvider for OpenAiCompatProvider {
             let args = serde_json::from_str(&buf.arguments)
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             content.push(Content::ToolCall {
+                provider_metadata: None,
                 id: buf.id.clone(),
                 name: buf.name.clone(),
                 arguments: args,
@@ -275,6 +276,7 @@ fn build_request_body(
                             id,
                             name,
                             arguments,
+                            ..
                         } => {
                             tool_calls.push(serde_json::json!({
                                 "id": id,
@@ -585,6 +587,7 @@ mod tests {
             messages: vec![
                 Message::Assistant {
                     content: vec![Content::ToolCall {
+                        provider_metadata: None,
                         id: "call-1".into(),
                         name: "read_file".into(),
                         arguments: serde_json::json!({"path": "img.png"}),

--- a/src/provider/openai_responses.rs
+++ b/src/provider/openai_responses.rs
@@ -178,6 +178,7 @@ impl StreamProvider for OpenAiResponsesProvider {
             let args = serde_json::from_str(&buf.arguments)
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             content.push(Content::ToolCall {
+                provider_metadata: None,
                 id: buf.id,
                 name: buf.name,
                 arguments: args,
@@ -266,6 +267,7 @@ fn build_request_body(config: &StreamConfig, _model_config: &ModelConfig) -> ser
                             id,
                             name,
                             arguments,
+                            ..
                         } => {
                             input.push(serde_json::json!({
                                 "type": "function_call",

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,6 +28,11 @@ pub enum Content {
         id: String,
         name: String,
         arguments: serde_json::Value,
+        /// Provider-specific metadata (e.g. Gemini thought signatures).
+        /// Not passed to tool execution; used by providers when building
+        /// the next request.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider_metadata: Option<serde_json::Value>,
     },
 }
 

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -99,6 +99,7 @@ async fn test_tool_call_and_response() {
     // Mock: first call returns tool use, second returns text
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "read_file".into(),
             arguments: serde_json::json!({"path": "test.txt"}),
         }]),
@@ -248,6 +249,7 @@ async fn test_continue_from_tool_result() {
 async fn test_tool_error_is_reported() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "failing_tool".into(),
             arguments: serde_json::json!({}),
         }]),
@@ -309,6 +311,7 @@ async fn test_tool_error_is_reported() {
 async fn test_unknown_tool_reports_error() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "nonexistent".into(),
             arguments: serde_json::json!({}),
         }]),
@@ -381,14 +384,17 @@ async fn test_parallel_tool_execution_faster_than_sequential() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_a".into(),
                 arguments: serde_json::json!({}),
             },
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_b".into(),
                 arguments: serde_json::json!({}),
             },
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_c".into(),
                 arguments: serde_json::json!({}),
             },
@@ -460,10 +466,12 @@ async fn test_sequential_tool_execution_is_slower() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_a".into(),
                 arguments: serde_json::json!({}),
             },
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_b".into(),
                 arguments: serde_json::json!({}),
             },
@@ -511,18 +519,22 @@ async fn test_batched_tool_execution() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_a".into(),
                 arguments: serde_json::json!({}),
             },
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_b".into(),
                 arguments: serde_json::json!({}),
             },
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_c".into(),
                 arguments: serde_json::json!({}),
             },
             MockToolCall {
+                provider_metadata: None,
                 name: "tool_d".into(),
                 arguments: serde_json::json!({}),
             },
@@ -631,6 +643,7 @@ impl AgentTool for ProgressTool {
 async fn test_tool_execution_update_events_emitted() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "progress_tool".into(),
             arguments: serde_json::json!({}),
         }]),
@@ -1050,15 +1063,18 @@ async fn test_before_turn_can_abort() {
     // We need tool calls to keep the loop going for multiple turns.
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "progress_tool".into(),
             arguments: serde_json::json!({}),
         }]),
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "progress_tool".into(),
             arguments: serde_json::json!({}),
         }]),
         // These should never be reached
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "progress_tool".into(),
             arguments: serde_json::json!({}),
         }]),
@@ -1101,6 +1117,7 @@ async fn test_before_turn_can_abort() {
 async fn test_after_turn_receives_messages() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "progress_tool".into(),
             arguments: serde_json::json!({}),
         }]),
@@ -1259,6 +1276,7 @@ impl AgentTool for ProgressMessageTool {
 async fn test_progress_message_event_emitted() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "progress_msg_tool".into(),
             arguments: serde_json::json!({}),
         }]),
@@ -1332,6 +1350,7 @@ impl AgentTool for SilentTool {
 async fn test_tool_ignoring_progress_no_panic() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "silent_tool".into(),
             arguments: serde_json::json!({}),
         }]),
@@ -1401,10 +1420,12 @@ async fn test_parallel_tools_progress_distinguishable() {
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![
             MockToolCall {
+                provider_metadata: None,
                 name: "pa".into(),
                 arguments: serde_json::json!({}),
             },
             MockToolCall {
+                provider_metadata: None,
                 name: "pb".into(),
                 arguments: serde_json::json!({}),
             },
@@ -1454,6 +1475,7 @@ async fn test_on_update_still_works_after_refactor() {
     // Existing ProgressTool uses on_update (not on_progress) — ensure it still works.
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "progress_tool".into(),
             arguments: serde_json::json!({}),
         }]),
@@ -1965,4 +1987,97 @@ async fn test_none_compaction_strategy_uses_default() {
         !new_messages.is_empty(),
         "Agent should have produced messages"
     );
+}
+
+/// Tool calls with provider_metadata (e.g. Gemini thought signatures)
+/// must still be executed by the agent loop.
+#[tokio::test]
+async fn test_tool_call_with_provider_metadata_executes() {
+    let provider = MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![MockToolCall {
+            name: "echo_tool".into(),
+            arguments: serde_json::json!({"text": "hello"}),
+            provider_metadata: Some(serde_json::json!({"thought_signature": "SIG_DATA"})),
+        }]),
+        MockResponse::Text("done".into()),
+    ]);
+
+    struct EchoTool;
+
+    #[async_trait::async_trait]
+    impl AgentTool for EchoTool {
+        fn name(&self) -> &str {
+            "echo_tool"
+        }
+        fn label(&self) -> &str {
+            "Echo"
+        }
+        fn description(&self) -> &str {
+            "Echoes input"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {"text": {"type": "string"}}})
+        }
+        async fn execute(
+            &self,
+            params: serde_json::Value,
+            _ctx: ToolContext,
+        ) -> Result<ToolResult, ToolError> {
+            let text = params["text"].as_str().unwrap_or("").to_string();
+            Ok(ToolResult {
+                content: vec![Content::Text { text }],
+                details: serde_json::Value::Null,
+            })
+        }
+    }
+
+    let config = make_config(provider);
+    let mut context = AgentContext {
+        system_prompt: String::new(),
+        messages: Vec::new(),
+        tools: vec![Box::new(EchoTool)],
+    };
+
+    let prompt = AgentMessage::Llm(Message::user("echo hello"));
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let cancel = CancellationToken::new();
+
+    let new_messages = agent_loop(vec![prompt], &mut context, &config, tx, cancel).await;
+
+    // Tool should have been executed despite provider_metadata being Some
+    let mut got_tool_start = false;
+    let mut got_tool_end = false;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            AgentEvent::ToolExecutionStart { tool_name, .. } => {
+                assert_eq!(tool_name, "echo_tool");
+                got_tool_start = true;
+            }
+            AgentEvent::ToolExecutionEnd { .. } => {
+                got_tool_end = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(got_tool_start, "Tool should have been executed");
+    assert!(got_tool_end, "Tool execution should have completed");
+
+    // Should have: user, assistant (tool call), tool result, assistant (final)
+    assert!(
+        new_messages.len() >= 4,
+        "Expected at least 4 messages, got {}",
+        new_messages.len()
+    );
+
+    // Verify tool result contains echoed text
+    let has_tool_result = new_messages.iter().any(|m| {
+        if let AgentMessage::Llm(Message::ToolResult { content, .. }) = m {
+            content
+                .iter()
+                .any(|c| matches!(c, Content::Text { text } if text == "hello"))
+        } else {
+            false
+        }
+    });
+    assert!(has_tool_result, "Tool result should contain 'hello'");
 }

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -80,6 +80,7 @@ async fn test_agent_with_tools() {
 
     let provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "echo".into(),
             arguments: serde_json::json!({"text": "hello"}),
         }]),

--- a/tests/integration_gemini.rs
+++ b/tests/integration_gemini.rs
@@ -1,0 +1,127 @@
+//! Integration tests against the real Google Gemini API.
+//! Run with: GEMINI_API_KEY=... cargo test --test integration_gemini -- --ignored
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use yoagent::agent_loop::{agent_loop, AgentLoopConfig};
+use yoagent::provider::{GoogleProvider, ModelConfig};
+use yoagent::tools;
+use yoagent::types::*;
+
+fn api_key() -> String {
+    std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set")
+}
+
+fn make_config(model: &str) -> AgentLoopConfig {
+    let model_config = ModelConfig::google(model, model);
+    AgentLoopConfig {
+        provider: std::sync::Arc::new(GoogleProvider),
+        model: model.into(),
+        api_key: api_key(),
+        thinking_level: ThinkingLevel::Off,
+        max_tokens: Some(1024),
+        temperature: None,
+        model_config: Some(model_config),
+        convert_to_llm: None,
+        transform_context: None,
+        get_steering_messages: None,
+        get_follow_up_messages: None,
+        context_config: None,
+        compaction_strategy: None,
+        execution_limits: None,
+        cache_config: CacheConfig {
+            enabled: false,
+            strategy: CacheStrategy::Disabled,
+        },
+        tool_execution: ToolExecutionStrategy::default(),
+        retry_config: yoagent::RetryConfig::default(),
+        before_turn: None,
+        after_turn: None,
+        on_error: None,
+        input_filters: vec![],
+    }
+}
+
+fn extract_assistant_text(messages: &[AgentMessage]) -> String {
+    messages
+        .iter()
+        .filter_map(|m| {
+            if let AgentMessage::Llm(Message::Assistant { content, .. }) = m {
+                Some(
+                    content
+                        .iter()
+                        .filter_map(|c| {
+                            if let Content::Text { text } = c {
+                                Some(text.as_str())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(""),
+                )
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Simple text response.
+#[tokio::test]
+#[ignore]
+async fn test_gemini_simple_text() {
+    let config = make_config("gemini-3-flash-preview");
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let cancel = CancellationToken::new();
+
+    let mut context = AgentContext {
+        system_prompt: "Reply with exactly one word.".into(),
+        messages: Vec::new(),
+        tools: Vec::new(),
+    };
+
+    let prompt = AgentMessage::Llm(Message::user("What color is the sky?"));
+    let new_messages = agent_loop(vec![prompt], &mut context, &config, tx, cancel).await;
+
+    let text = extract_assistant_text(&new_messages);
+    assert!(!text.is_empty(), "Expected non-empty response");
+    println!("Response: {}", text);
+}
+
+/// Function tool use with Gemini.
+#[tokio::test]
+#[ignore]
+async fn test_gemini_tool_use() {
+    let config = make_config("gemini-3-flash-preview");
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let cancel = CancellationToken::new();
+
+    let mut context = AgentContext {
+        system_prompt: "Use the bash tool to answer. Be concise.".into(),
+        messages: Vec::new(),
+        tools: tools::default_tools(),
+    };
+
+    let prompt = AgentMessage::Llm(Message::user(
+        "What is the output of `echo hello_gemini`? Use bash to run it.",
+    ));
+    let new_messages = agent_loop(vec![prompt], &mut context, &config, tx, cancel).await;
+
+    let text = extract_assistant_text(&new_messages);
+    assert!(
+        text.contains("hello_gemini"),
+        "Expected response with tool output, got: {}",
+        text
+    );
+
+    let mut got_tool_execution = false;
+    while let Ok(event) = rx.try_recv() {
+        if matches!(event, AgentEvent::ToolExecutionStart { .. }) {
+            got_tool_execution = true;
+        }
+    }
+    assert!(got_tool_execution, "Expected tool execution");
+    println!("Response: {}", text);
+}

--- a/tests/serialization_test.rs
+++ b/tests/serialization_test.rs
@@ -33,6 +33,7 @@ fn test_message_assistant_roundtrip() {
                 text: "Hi there".into(),
             },
             Content::ToolCall {
+                provider_metadata: None,
                 id: "tc-1".into(),
                 name: "read_file".into(),
                 arguments: serde_json::json!({"path": "foo.rs"}),
@@ -105,6 +106,7 @@ fn test_content_variants_roundtrip() {
         signature: Some("sig123".into()),
     });
     roundtrip(&Content::ToolCall {
+        provider_metadata: None,
         id: "tc-1".into(),
         name: "bash".into(),
         arguments: serde_json::json!({"command": "ls"}),
@@ -121,6 +123,7 @@ fn test_full_conversation_roundtrip() {
         AgentMessage::Llm(Message::user("Read the file")),
         AgentMessage::Llm(Message::Assistant {
             content: vec![Content::ToolCall {
+                provider_metadata: None,
                 id: "tc-1".into(),
                 name: "read_file".into(),
                 arguments: serde_json::json!({"path": "main.rs"}),

--- a/tests/sub_agent_test.rs
+++ b/tests/sub_agent_test.rs
@@ -131,6 +131,7 @@ async fn test_sub_agent_with_tools() {
     // Sub-agent first calls the echo tool, then responds with text
     let sub_provider = Arc::new(MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "echo".into(),
             arguments: serde_json::json!({"text": "hello"}),
         }]),
@@ -225,6 +226,7 @@ async fn test_sub_agent_max_turns() {
     // The sub-agent won't get a second LLM call to produce text.
     let sub_provider = Arc::new(MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "echo".into(),
             arguments: serde_json::json!({"text": "loop"}),
         }]),
@@ -339,10 +341,12 @@ async fn test_sub_agent_parallel() {
     let parent_provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![
             MockToolCall {
+                provider_metadata: None,
                 name: "agent_a".into(),
                 arguments: serde_json::json!({"task": "Do A"}),
             },
             MockToolCall {
+                provider_metadata: None,
                 name: "agent_b".into(),
                 arguments: serde_json::json!({"task": "Do B"}),
             },
@@ -491,6 +495,7 @@ async fn test_sub_agent_in_parent_loop() {
 
     let parent_provider = MockProvider::new(vec![
         MockResponse::ToolCalls(vec![MockToolCall {
+            provider_metadata: None,
             name: "calculator".into(),
             arguments: serde_json::json!({"task": "What is 6*7?"}),
         }]),


### PR DESCRIPTION
Fixes several issues with the Google Gemini provider that break streaming and function calling.

**SSE parsing**
- Handle `\r\n` line endings (Google's API uses CRLF, parser only handled LF)
- Skip empty text parts sent during the thinking phase
- Upgrade parse error logging from `debug!` to `warn!`

**Function calling**
- Don't let `finishReason: "STOP"` override `StopReason::ToolUse` -- Gemini returns "STOP" even when it emits function calls, so the agent loop never executed tools
- Capture and round-trip thought signatures via `provider_metadata` field on `Content::ToolCall` (keeps provider-specific data out of tool arguments)
- Use real function call `id` from response, with synthetic `google-fc-{n}` fallback for models that omit it
- Include `id` in `functionResponse` when sending tool results back

**`Content::ToolCall` change**
- Add optional `provider_metadata: Option<serde_json::Value>` field for provider-specific data that shouldn't reach tool execution
- All pattern match sites use `..` to ignore the field; only construction sites set it explicitly

**Tests**
- 7 unit tests: SSE parsing, thought signature round-tripping, function call ID handling
- 1 MockProvider test: verifies agent loop executes tools when `provider_metadata` is `Some(...)`
- 2 integration tests: simple text, tool use with bash (gemini-3-flash-preview)

---

Generated with LLM assistance (Claude Code). Changes have been manually exercised against live APIs via [yoke](https://github.com/cablehead/yoke), a headless agent harness built on yoagent.