### PR TITLE
release: 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -176,13 +176,13 @@ Found 3 TODOs:
 <summary>OpenAI-compatible provider example</summary>
 
 ```rust
-use yoagent::provider::{ModelConfig, ApiProtocol, ProviderRegistry};
+use yoagent::provider::{ModelConfig, ProviderRegistry};
 
-// Use any OpenAI-compatible provider
-let model = ModelConfig::openai_compat("groq", "llama-3.3-70b", "https://api.groq.com/openai/v1");
+// Use a first-class OpenAI-compatible provider preset
+let model = ModelConfig::groq("llama-3.3-70b-versatile", "Llama 3.3 70B");
 
 // Or Google Gemini
-let model = ModelConfig::google("gemini-2.5-pro");
+let model = ModelConfig::google("gemini-2.5-pro", "Gemini 2.5 Pro");
 
 // Registry dispatches to the right provider
 let registry = ProviderRegistry::default();
@@ -197,7 +197,7 @@ let registry = ProviderRegistry::default();
 | Protocol | Providers |
 |----------|-----------|
 | Anthropic Messages | Anthropic (Claude) |
-| OpenAI Completions | OpenAI, xAI, Groq, Cerebras, OpenRouter, Mistral, MiniMax, HuggingFace, Kimi, DeepSeek |
+| OpenAI Completions | OpenAI, xAI, Groq, Mistral, DeepSeek, MiniMax, Z.ai, local servers, and custom compatible APIs |
 | OpenAI Responses | OpenAI (newer API) |
 | Azure OpenAI | Azure OpenAI |
 | Google Generative AI | Google Gemini |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@
 # Providers
 
 - [Overview](providers/overview.md)
+- [Model Presets](providers/model-presets.md)
 - [Anthropic](providers/anthropic.md)
 - [OpenAI Compatible](providers/openai-compat.md)
 - [Google Gemini](providers/google.md)

--- a/docs/concepts/sub-agents.md
+++ b/docs/concepts/sub-agents.md
@@ -187,7 +187,7 @@ let analyst = SubAgentTool::new("analyst", provider)
     .with_tools(vec![...]);
 ```
 
-This works with all providers: OpenAI, Groq, DeepSeek, Gemini, Mistral, xAI, and more. See [`ModelConfig`](../reference/configuration.md) for the full list of factory methods.
+This works with all providers: OpenAI, Groq, DeepSeek, Gemini, Mistral, xAI, and more. See [Model Presets](../providers/model-presets.md) for the full list of first-class factory methods.
 
 ## Design Decisions
 

--- a/docs/providers/model-presets.md
+++ b/docs/providers/model-presets.md
@@ -1,0 +1,85 @@
+# Model Presets
+
+yoagent's first-class model presets are the `ModelConfig::*` constructors. A preset sets provider routing, base URL, context metadata, default output limits, and provider compatibility flags.
+
+Use a preset when the provider is listed here. Use a custom `ModelConfig` when you need a compatible provider or endpoint that does not have a constructor yet.
+
+## First-Class Constructors
+
+| Constructor | Provider | Protocol | Default Base URL | Context | Default Max Output |
+|-------------|----------|----------|------------------|---------|--------------------|
+| `ModelConfig::anthropic(id, name)` | Anthropic | `AnthropicMessages` | `https://api.anthropic.com` | 200K | 8,192 |
+| `ModelConfig::openai(id, name)` | OpenAI | `OpenAiCompletions` | `https://api.openai.com/v1` | 128K | 4,096 |
+| `ModelConfig::google(id, name)` | Google Gemini | `GoogleGenerativeAi` | `https://generativelanguage.googleapis.com` | 1M | 8,192 |
+| `ModelConfig::xai(id, name)` | xAI | `OpenAiCompletions` | `https://api.x.ai/v1` | 131,072 | 4,096 |
+| `ModelConfig::groq(id, name)` | Groq | `OpenAiCompletions` | `https://api.groq.com/openai/v1` | 128K | 4,096 |
+| `ModelConfig::deepseek(id, name)` | DeepSeek | `OpenAiCompletions` | `https://api.deepseek.com` | 1M | 384K |
+| `ModelConfig::mistral(id, name)` | Mistral | `OpenAiCompletions` | `https://api.mistral.ai/v1` | 128K | 4,096 |
+| `ModelConfig::minimax(id, name)` | MiniMax | `OpenAiCompletions` | `https://api.minimaxi.chat/v1` | 1M | 4,096 |
+| `ModelConfig::zai(id, name)` | Z.ai | `OpenAiCompletions` | `https://api.z.ai/api/paas/v4` | 128K | 4,096 |
+| `ModelConfig::local(base_url, model_id)` | Local compatible server | `OpenAiCompletions` | caller provided | 128K | 4,096 |
+
+The constructors do not validate model IDs. They send the `id` you pass through to the provider, which lets you use newly released model IDs before yoagent updates its examples.
+
+## OpenAI-Compatible Presets
+
+These constructors all use `OpenAiCompatProvider`:
+
+```rust
+use yoagent::provider::{ModelConfig, OpenAiCompatProvider};
+
+let agent = Agent::new(OpenAiCompatProvider)
+    .with_model_config(ModelConfig::deepseek(
+        "deepseek-v4-flash",
+        "DeepSeek V4 Flash",
+    ))
+    .with_model("deepseek-v4-flash")
+    .with_api_key(std::env::var("DEEPSEEK_API_KEY").unwrap());
+```
+
+OpenAI-compatible presets also set `OpenAiCompat` flags for provider-specific API differences, such as `max_tokens` vs. `max_completion_tokens`, reasoning fields, tool result formatting, and streaming usage support. See [OpenAI Compatible](openai-compat.md) for the full quirk-flag list.
+
+## DeepSeek Models
+
+Use the current DeepSeek API model IDs by default:
+
+```rust
+let flash = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek V4 Flash");
+let pro = ModelConfig::deepseek("deepseek-v4-pro", "DeepSeek V4 Pro");
+```
+
+Legacy DeepSeek aliases still work because `ModelConfig::deepseek` passes the model ID through unchanged:
+
+```rust
+let chat = ModelConfig::deepseek("deepseek-chat", "DeepSeek Chat");
+let reasoner = ModelConfig::deepseek("deepseek-reasoner", "DeepSeek Reasoner");
+```
+
+DeepSeek documents `deepseek-chat` and `deepseek-reasoner` as compatibility aliases scheduled for deprecation on 2026-07-24. In DeepSeek's current API, `deepseek-chat` maps to the non-thinking mode of `deepseek-v4-flash`, while `deepseek-reasoner` maps to the thinking mode of `deepseek-v4-flash`.
+
+yoagent also sends DeepSeek's current request shape:
+
+- `max_tokens`, not `max_completion_tokens`
+- `thinking: { "type": "enabled" | "disabled" }`
+- `reasoning_effort` when `ThinkingLevel` is not `Off`
+- DeepSeek cache hit/miss usage fields when present
+
+For legacy aliases, set `ThinkingLevel` to match the alias behavior:
+
+```rust
+let chat_agent = Agent::new(OpenAiCompatProvider)
+    .with_model_config(ModelConfig::deepseek("deepseek-chat", "DeepSeek Chat"))
+    .with_model("deepseek-chat")
+    .with_thinking_level(ThinkingLevel::Off);
+
+let reasoner_agent = Agent::new(OpenAiCompatProvider)
+    .with_model_config(ModelConfig::deepseek("deepseek-reasoner", "DeepSeek Reasoner"))
+    .with_model("deepseek-reasoner")
+    .with_thinking_level(ThinkingLevel::High);
+```
+
+Older DeepSeek reasoning models had stricter feature limits than the current V4 API. In particular, historical `deepseek-reasoner` documentation did not support function calling. If you need tools, prefer current V4 model IDs unless you have tested the legacy alias for your workflow.
+
+## Compat Flags Without Constructors
+
+`OpenAiCompat` also has quirk presets such as `OpenAiCompat::cerebras()` and `OpenAiCompat::openrouter()`. Those are compatibility profiles, not full `ModelConfig` constructors. To use them, build a custom `ModelConfig` with the provider name, base URL, protocol, and `compat` value you need.

--- a/docs/providers/openai-compat.md
+++ b/docs/providers/openai-compat.md
@@ -2,6 +2,8 @@
 
 `OpenAiCompatProvider` implements the OpenAI Chat Completions API. One implementation covers OpenAI, xAI, Groq, Cerebras, OpenRouter, Mistral, DeepSeek, MiniMax, Z.ai, and any other compatible API.
 
+For the first-class `ModelConfig::*` constructors and default model metadata, see [Model Presets](model-presets.md).
+
 ## Usage
 
 Requires a `ModelConfig` with `compat` flags set in `StreamConfig.model_config`:
@@ -23,6 +25,7 @@ pub struct OpenAiCompat {
     pub supports_store: bool,
     pub supports_developer_role: bool,
     pub supports_reasoning_effort: bool,
+    pub supports_thinking_control: bool,
     pub supports_usage_in_streaming: bool,
     pub max_tokens_field: MaxTokensField,       // MaxTokens or MaxCompletionTokens
     pub requires_tool_result_name: bool,
@@ -41,9 +44,11 @@ pub struct OpenAiCompat {
 | Cerebras | `OpenAiCompat::cerebras()` | Standard defaults |
 | OpenRouter | `OpenAiCompat::openrouter()` | `max_completion_tokens` |
 | Mistral | `OpenAiCompat::mistral()` | `max_tokens` field |
-| DeepSeek | `OpenAiCompat::deepseek()` | `max_completion_tokens` |
+| DeepSeek | `OpenAiCompat::deepseek()` | `max_tokens`, `thinking`, `reasoning_effort`, 1M context window |
 | MiniMax | `OpenAiCompat::minimax()` | Standard defaults, 1M context window |
 | Z.ai (Zhipu) | `OpenAiCompat::zai()` | Standard defaults |
+
+`OpenAiCompat` presets are lower-level quirk flags. A provider is first-class when it also has a `ModelConfig::*` constructor; see [Model Presets](model-presets.md).
 
 ## Adding a New Compatible Provider
 

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -48,7 +48,7 @@ pub struct ModelConfig {
 }
 ```
 
-Convenience constructors:
+First-class model presets are documented in [Model Presets](model-presets.md). Convenience constructors:
 
 ```rust
 let anthropic = ModelConfig::anthropic("claude-sonnet-4-20250514", "Claude Sonnet 4");
@@ -56,7 +56,7 @@ let openai = ModelConfig::openai("gpt-4o", "GPT-4o");
 let google = ModelConfig::google("gemini-2.0-flash", "Gemini 2.0 Flash");
 let xai = ModelConfig::xai("grok-3-mini", "Grok 3 Mini");
 let groq = ModelConfig::groq("llama-3.3-70b-versatile", "Llama 3.3 70B");
-let deepseek = ModelConfig::deepseek("deepseek-chat", "DeepSeek Chat");
+let deepseek = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek V4 Flash");
 let mistral = ModelConfig::mistral("mistral-large-latest", "Mistral Large");
 let minimax = ModelConfig::minimax("MiniMax-Text-01", "MiniMax Text 01");
 let zai = ModelConfig::zai("glm-4.7", "GLM 4.7");

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -108,3 +108,9 @@ pub struct CostConfig {
     pub cache_write_per_million: f64,
 }
 ```
+
+## ModelConfig Presets
+
+yoagent provides first-class `ModelConfig::*` constructors for Anthropic, OpenAI, Google Gemini, xAI, Groq, DeepSeek, Mistral, MiniMax, Z.ai, and local OpenAI-compatible servers.
+
+See [Model Presets](../providers/model-presets.md) for the full table of constructors, default base URLs, context windows, and DeepSeek legacy alias notes.

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -89,7 +89,7 @@ async fn main() {
         Some("openai") => "gpt-4o",
         Some("xai") => "grok-3-mini",
         Some("groq") => "llama-3.3-70b-versatile",
-        Some("deepseek") => "deepseek-chat",
+        Some("deepseek") => "deepseek-v4-flash",
         Some("mistral") => "mistral-large-latest",
         Some("minimax") => "MiniMax-Text-01",
         Some("google") => "gemini-2.5-pro",

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -431,7 +431,9 @@ async fn run_loop(
             // Track turn for execution limits
             if let Some(ref mut tracker) = tracker {
                 let turn_tokens = match &message {
-                    Message::Assistant { usage, .. } => (usage.input + usage.output) as usize,
+                    Message::Assistant { usage, .. } => {
+                        (usage.input + usage.output + usage.cache_read + usage.cache_write) as usize
+                    }
                     _ => context::message_tokens(&agent_msg),
                 };
                 tracker.record_turn(turn_tokens);

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -81,6 +81,9 @@ pub struct OpenAiCompat {
     pub supports_developer_role: bool,
     /// Supports `reasoning_effort` parameter.
     pub supports_reasoning_effort: bool,
+    /// Supports DeepSeek-style `thinking` mode control.
+    #[serde(default)]
+    pub supports_thinking_control: bool,
     /// Includes usage data in streaming responses.
     pub supports_usage_in_streaming: bool,
     /// Which field name to use for max tokens.
@@ -99,6 +102,7 @@ impl Default for OpenAiCompat {
             supports_store: false,
             supports_developer_role: false,
             supports_reasoning_effort: false,
+            supports_thinking_control: false,
             supports_usage_in_streaming: true,
             max_tokens_field: MaxTokensField::MaxTokens,
             requires_tool_result_name: false,
@@ -164,8 +168,10 @@ impl OpenAiCompat {
     /// Compat flags for DeepSeek.
     pub fn deepseek() -> Self {
         Self {
+            supports_reasoning_effort: true,
+            supports_thinking_control: true,
             supports_usage_in_streaming: true,
-            max_tokens_field: MaxTokensField::MaxCompletionTokens,
+            max_tokens_field: MaxTokensField::MaxTokens,
             ..Default::default()
         }
     }
@@ -348,17 +354,20 @@ impl ModelConfig {
 
     /// Create a new DeepSeek model config.
     ///
-    /// Models: `deepseek-chat`, `deepseek-reasoner`, etc.
+    /// Models: `deepseek-v4-flash`, `deepseek-v4-pro`, etc.
+    ///
+    /// Legacy aliases `deepseek-chat` and `deepseek-reasoner` are accepted by
+    /// DeepSeek for now, but are scheduled for deprecation on 2026-07-24.
     pub fn deepseek(id: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             id: id.into(),
             name: name.into(),
             api: ApiProtocol::OpenAiCompletions,
             provider: "deepseek".into(),
-            base_url: "https://api.deepseek.com/v1".into(),
-            reasoning: false,
-            context_window: 128_000,
-            max_tokens: 4096,
+            base_url: "https://api.deepseek.com".into(),
+            reasoning: true,
+            context_window: 1_000_000,
+            max_tokens: 384_000,
             cost: CostConfig::default(),
             headers: HashMap::new(),
             compat: Some(OpenAiCompat::deepseek()),
@@ -435,10 +444,9 @@ mod tests {
         assert!(!groq.supports_store);
 
         let deepseek = OpenAiCompat::deepseek();
-        assert_eq!(
-            deepseek.max_tokens_field,
-            MaxTokensField::MaxCompletionTokens
-        );
+        assert_eq!(deepseek.max_tokens_field, MaxTokensField::MaxTokens);
+        assert!(deepseek.supports_reasoning_effort);
+        assert!(deepseek.supports_thinking_control);
 
         let zai = OpenAiCompat::zai();
         assert!(zai.supports_usage_in_streaming);
@@ -465,6 +473,18 @@ mod tests {
         assert_eq!(config.provider, "minimax");
         assert_eq!(config.base_url, "https://api.minimaxi.chat/v1");
         assert_eq!(config.context_window, 1_000_000);
+        assert!(config.compat.is_some());
+    }
+
+    #[test]
+    fn test_model_config_deepseek() {
+        let config = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek V4 Flash");
+        assert_eq!(config.api, ApiProtocol::OpenAiCompletions);
+        assert_eq!(config.provider, "deepseek");
+        assert_eq!(config.base_url, "https://api.deepseek.com");
+        assert_eq!(config.context_window, 1_000_000);
+        assert_eq!(config.max_tokens, 384_000);
+        assert!(config.reasoning);
         assert!(config.compat.is_some());
     }
 

--- a/src/provider/openai_compat.rs
+++ b/src/provider/openai_compat.rs
@@ -85,12 +85,18 @@ impl StreamProvider for OpenAiCompatProvider {
 
                             // Process usage
                             if let Some(u) = &chunk.usage {
-                                usage.input = u.prompt_tokens;
+                                let cache_read = u
+                                    .prompt_cache_hit_tokens
+                                    .or_else(|| {
+                                        u.prompt_tokens_details.as_ref().map(|d| d.cached_tokens)
+                                    })
+                                    .unwrap_or(0);
+                                usage.input = u.prompt_cache_miss_tokens.unwrap_or_else(|| {
+                                    u.prompt_tokens.saturating_sub(cache_read)
+                                });
                                 usage.output = u.completion_tokens;
                                 usage.total_tokens = u.total_tokens;
-                                if let Some(details) = &u.prompt_tokens_details {
-                                    usage.cache_read = details.cached_tokens;
-                                }
+                                usage.cache_read = cache_read;
                             }
 
                             for choice in &chunk.choices {
@@ -348,6 +354,15 @@ fn build_request_body(
         }
     }
 
+    if compat.supports_thinking_control {
+        let thinking_type = if config.thinking_level == ThinkingLevel::Off {
+            "disabled"
+        } else {
+            "enabled"
+        };
+        body["thinking"] = serde_json::json!({ "type": thinking_type });
+    }
+
     if !config.tools.is_empty() {
         let tools: Vec<serde_json::Value> = config
             .tools
@@ -462,6 +477,10 @@ struct OpenAiUsage {
     total_tokens: u64,
     #[serde(default)]
     prompt_tokens_details: Option<OpenAiPromptTokensDetails>,
+    #[serde(default)]
+    prompt_cache_hit_tokens: Option<u64>,
+    #[serde(default)]
+    prompt_cache_miss_tokens: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -526,6 +545,78 @@ mod tests {
         assert!(body["tools"].is_array());
         assert_eq!(body["tools"][0]["function"]["name"], "bash");
         assert_eq!(body["temperature"], 0.5);
+    }
+
+    #[test]
+    fn test_build_request_body_deepseek_off_uses_current_api_shape() {
+        let model_config = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek V4 Flash");
+        let compat = model_config.compat.as_ref().unwrap().clone();
+        let config = StreamConfig {
+            model: "deepseek-v4-flash".into(),
+            system_prompt: "You are helpful.".into(),
+            messages: vec![Message::user("Hello")],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Off,
+            api_key: "test".into(),
+            max_tokens: Some(1024),
+            temperature: None,
+            model_config: Some(model_config.clone()),
+            cache_config: CacheConfig::default(),
+        };
+
+        let body = build_request_body(&config, &model_config, &compat);
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["max_tokens"], 1024);
+        assert!(body.get("max_completion_tokens").is_none());
+        assert_eq!(body["thinking"]["type"], "disabled");
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_build_request_body_deepseek_thinking_enabled() {
+        let model_config = ModelConfig::deepseek("deepseek-v4-pro", "DeepSeek V4 Pro");
+        let compat = model_config.compat.as_ref().unwrap().clone();
+        let config = StreamConfig {
+            model: "deepseek-v4-pro".into(),
+            system_prompt: String::new(),
+            messages: vec![Message::user("Solve this")],
+            tools: vec![],
+            thinking_level: ThinkingLevel::High,
+            api_key: "test".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: Some(model_config.clone()),
+            cache_config: CacheConfig::default(),
+        };
+
+        let body = build_request_body(&config, &model_config, &compat);
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["reasoning_effort"], "high");
+        assert_eq!(body["max_tokens"], 384_000);
+    }
+
+    #[test]
+    fn test_deepseek_usage_cache_fields_parse() {
+        let chunk: OpenAiChunk = serde_json::from_value(serde_json::json!({
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 100,
+                "prompt_cache_hit_tokens": 70,
+                "prompt_cache_miss_tokens": 30,
+                "completion_tokens": 10,
+                "total_tokens": 110
+            }
+        }))
+        .unwrap();
+
+        let u = chunk.usage.unwrap();
+        let cache_read = u.prompt_cache_hit_tokens.unwrap_or(0);
+        let input = u
+            .prompt_cache_miss_tokens
+            .unwrap_or_else(|| u.prompt_tokens.saturating_sub(cache_read));
+        assert_eq!(input, 30);
+        assert_eq!(cache_read, 70);
+        assert_eq!(u.completion_tokens, 10);
     }
 
     #[test]

--- a/tests/agent_loop_test.rs
+++ b/tests/agent_loop_test.rs
@@ -3,6 +3,7 @@
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use yoagent::agent_loop::{agent_loop, agent_loop_continue, AgentLoopConfig};
+use yoagent::context::ExecutionLimits;
 use yoagent::provider::mock::*;
 use yoagent::provider::MockProvider;
 use yoagent::*;
@@ -697,6 +698,120 @@ struct FailThenSucceedProvider {
 }
 
 use yoagent::provider::{ProviderError, StreamConfig, StreamEvent, StreamProvider};
+
+struct UsageProvider {
+    usage: Usage,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl StreamProvider for UsageProvider {
+    async fn stream(
+        &self,
+        _config: StreamConfig,
+        tx: tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<yoagent::Message, ProviderError> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        let message = Message::Assistant {
+            content: vec![Content::Text {
+                text: "usage response".into(),
+            }],
+            stop_reason: StopReason::Stop,
+            model: "usage-test".into(),
+            provider: "usage-test".into(),
+            usage: self.usage.clone(),
+            timestamp: now_ms(),
+            error_message: None,
+        };
+
+        let _ = tx.send(StreamEvent::Start);
+        let _ = tx.send(StreamEvent::Done {
+            message: message.clone(),
+        });
+        Ok(message)
+    }
+}
+
+#[tokio::test]
+async fn test_execution_limit_counts_cached_tokens() {
+    let provider = std::sync::Arc::new(UsageProvider {
+        usage: Usage {
+            input: 1,
+            output: 1,
+            cache_read: 99,
+            cache_write: 0,
+            total_tokens: 101,
+        },
+        calls: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let provider_for_config: std::sync::Arc<dyn StreamProvider> = provider.clone();
+
+    let config = AgentLoopConfig {
+        provider: provider_for_config,
+        model: "usage-test".into(),
+        api_key: "test".into(),
+        thinking_level: ThinkingLevel::Off,
+        max_tokens: None,
+        temperature: None,
+        model_config: None,
+        convert_to_llm: None,
+        transform_context: None,
+        get_steering_messages: None,
+        get_follow_up_messages: Some(Box::new(|| {
+            vec![AgentMessage::Llm(Message::user("follow up"))]
+        })),
+        context_config: None,
+        compaction_strategy: None,
+        execution_limits: Some(ExecutionLimits {
+            max_turns: 50,
+            max_total_tokens: 100,
+            max_duration: std::time::Duration::from_secs(60),
+        }),
+        cache_config: CacheConfig::default(),
+        tool_execution: ToolExecutionStrategy::default(),
+        retry_config: yoagent::RetryConfig::default(),
+        before_turn: None,
+        after_turn: None,
+        on_error: None,
+        input_filters: vec![],
+        turn_delay: None,
+    };
+
+    let mut context = AgentContext {
+        system_prompt: "test".into(),
+        messages: Vec::new(),
+        tools: Vec::new(),
+    };
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let cancel = CancellationToken::new();
+
+    let new_messages = agent_loop(
+        vec![AgentMessage::Llm(Message::user("start"))],
+        &mut context,
+        &config,
+        tx,
+        cancel,
+    )
+    .await;
+
+    assert_eq!(
+        provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "cached prompt tokens should trip the limit before a second provider call"
+    );
+    assert!(new_messages.iter().any(|msg| {
+        matches!(
+            msg,
+            AgentMessage::Llm(Message::User { content, .. })
+                if content.iter().any(|c| matches!(
+                    c,
+                    Content::Text { text } if text.contains("[Agent stopped: Max tokens reached")
+                ))
+        )
+    }));
+}
 
 #[async_trait::async_trait]
 impl StreamProvider for FailThenSucceedProvider {


### PR DESCRIPTION
## Summary

- update DeepSeek OpenAI-compatible defaults for the current V4 API shape
- add first-class model preset documentation and provider docs links
- parse OpenAI-compatible cache usage fields and count cached prompt tokens in execution limits

## Validation

- `cargo fmt --check`
- `cargo test`

## Release

- Bumps crate version to `0.8.1`
- After merge, publish GitHub Release `v0.8.1` to trigger the crates.io workflow
