### PR TITLE
Add first-class Ollama preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ See [docs/concepts/skills.md](docs/concepts/skills.md) for the full guide.
 ANTHROPIC_API_KEY=sk-... cargo run --example cli
 # With skills:
 ANTHROPIC_API_KEY=sk-... cargo run --example cli -- --skills ./skills
-# With a local server (LM Studio, Ollama, llama.cpp, vLLM):
+# With Ollama:
+cargo run --example cli -- --provider ollama --model llama3.1:8b
+# With another local server (LM Studio, llama.cpp, vLLM):
 cargo run --example cli -- --api-url http://localhost:1234/v1 --model my-model
 ```
 
@@ -197,7 +199,7 @@ let registry = ProviderRegistry::default();
 | Protocol | Providers |
 |----------|-----------|
 | Anthropic Messages | Anthropic (Claude) |
-| OpenAI Completions | OpenAI, xAI, Groq, Mistral, DeepSeek, MiniMax, Z.ai, local servers, and custom compatible APIs |
+| OpenAI Completions | OpenAI, xAI, Groq, Mistral, DeepSeek, MiniMax, Z.ai, Ollama, local servers, and custom compatible APIs |
 | OpenAI Responses | OpenAI (newer API) |
 | Azure OpenAI | Azure OpenAI |
 | Google Generative AI | Google Gemini |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -45,7 +45,7 @@ async fn main() {
 
 ## Example with OpenAI-Compatible Provider
 
-For OpenAI, xAI, Groq, DeepSeek, Mistral, MiniMax, Z.ai, or any compatible API, use `OpenAiCompatProvider` with a `ModelConfig`:
+For OpenAI, xAI, Groq, DeepSeek, Mistral, MiniMax, Z.ai, Ollama, or any compatible API, use `OpenAiCompatProvider` with a `ModelConfig`:
 
 ```rust
 use yoagent::{Agent, AgentEvent};

--- a/docs/providers/model-presets.md
+++ b/docs/providers/model-presets.md
@@ -17,6 +17,7 @@ Use a preset when the provider is listed here. Use a custom `ModelConfig` when y
 | `ModelConfig::mistral(id, name)` | Mistral | `OpenAiCompletions` | `https://api.mistral.ai/v1` | 128K | 4,096 |
 | `ModelConfig::minimax(id, name)` | MiniMax | `OpenAiCompletions` | `https://api.minimaxi.chat/v1` | 1M | 4,096 |
 | `ModelConfig::zai(id, name)` | Z.ai | `OpenAiCompletions` | `https://api.z.ai/api/paas/v4` | 128K | 4,096 |
+| `ModelConfig::ollama(base_url, model_id)` | Ollama | `OpenAiCompletions` | caller provided | 128K | 4,096 |
 | `ModelConfig::local(base_url, model_id)` | Local compatible server | `OpenAiCompletions` | caller provided | 128K | 4,096 |
 
 The constructors do not validate model IDs. They send the `id` you pass through to the provider, which lets you use newly released model IDs before yoagent updates its examples.
@@ -38,6 +39,16 @@ let agent = Agent::new(OpenAiCompatProvider)
 ```
 
 OpenAI-compatible presets also set `OpenAiCompat` flags for provider-specific API differences, such as `max_tokens` vs. `max_completion_tokens`, reasoning fields, tool result formatting, and streaming usage support. See [OpenAI Compatible](openai-compat.md) for the full quirk-flag list.
+
+## Ollama Models
+
+Use `ModelConfig::ollama` for Ollama's OpenAI-compatible endpoint:
+
+```rust
+let llama = ModelConfig::ollama("http://localhost:11434/v1", "llama3.1:8b");
+```
+
+Ollama remains separate from `ModelConfig::local(...)` because some Ollama-served models need an assistant message after tool results, while other local OpenAI-compatible servers may not. The Ollama preset enables that transcript workaround; the generic local preset stays neutral.
 
 ## DeepSeek Models
 

--- a/docs/providers/openai-compat.md
+++ b/docs/providers/openai-compat.md
@@ -47,6 +47,7 @@ pub struct OpenAiCompat {
 | DeepSeek | `OpenAiCompat::deepseek()` | `max_tokens`, `thinking`, `reasoning_effort`, 1M context window |
 | MiniMax | `OpenAiCompat::minimax()` | Standard defaults, 1M context window |
 | Z.ai (Zhipu) | `OpenAiCompat::zai()` | Standard defaults |
+| Ollama | `OpenAiCompat::ollama()` | Inserts an empty assistant message after tool result runs |
 
 `OpenAiCompat` presets are lower-level quirk flags. A provider is first-class when it also has a `ModelConfig::*` constructor; see [Model Presets](model-presets.md).
 
@@ -90,7 +91,7 @@ The `ThinkingFormat` enum controls how reasoning content is parsed from streams:
 
 ## Local Servers (LM Studio, Ollama, llama.cpp, vLLM)
 
-Use `ModelConfig::local()` for any local OpenAI-compatible server. No API key required:
+Use `ModelConfig::ollama()` for Ollama, or `ModelConfig::local()` for any other local OpenAI-compatible server. No API key required:
 
 ```rust
 use yoagent::agent::Agent;
@@ -100,6 +101,15 @@ let agent = Agent::new(OpenAiCompatProvider)
     .with_model_config(ModelConfig::local("http://localhost:1234/v1", "my-model"))
     .with_model("my-model")
     .with_api_key(""); // empty string OK for local
+```
+
+For Ollama:
+
+```rust
+let agent = Agent::new(OpenAiCompatProvider)
+    .with_model_config(ModelConfig::ollama("http://localhost:11434/v1", "llama3.1:8b"))
+    .with_model("llama3.1:8b")
+    .with_api_key("");
 ```
 
 Or via the CLI example:

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -60,6 +60,7 @@ let deepseek = ModelConfig::deepseek("deepseek-v4-flash", "DeepSeek V4 Flash");
 let mistral = ModelConfig::mistral("mistral-large-latest", "Mistral Large");
 let minimax = ModelConfig::minimax("MiniMax-Text-01", "MiniMax Text 01");
 let zai = ModelConfig::zai("glm-4.7", "GLM 4.7");
+let ollama = ModelConfig::ollama("http://localhost:11434/v1", "llama3.1:8b");
 let local = ModelConfig::local("http://localhost:1234/v1", "my-model");
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -111,6 +111,6 @@ pub struct CostConfig {
 
 ## ModelConfig Presets
 
-yoagent provides first-class `ModelConfig::*` constructors for Anthropic, OpenAI, Google Gemini, xAI, Groq, DeepSeek, Mistral, MiniMax, Z.ai, and local OpenAI-compatible servers.
+yoagent provides first-class `ModelConfig::*` constructors for Anthropic, OpenAI, Google Gemini, xAI, Groq, DeepSeek, Mistral, MiniMax, Z.ai, Ollama, and local OpenAI-compatible servers.
 
 See [Model Presets](../providers/model-presets.md) for the full table of constructors, default base URLs, context windows, and DeepSeek legacy alias notes.

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -11,10 +11,11 @@
 //!   ANTHROPIC_API_KEY=sk-... cargo run --example cli -- --model claude-sonnet-4-20250514
 //!   ANTHROPIC_API_KEY=sk-... cargo run --example cli -- --skills ./skills
 //!
-//! Run with a named provider (zai, openai, xai, groq, deepseek, mistral, minimax, google):
+//! Run with a named provider (zai, openai, xai, groq, deepseek, mistral, minimax, ollama, google):
 //!   API_KEY=... cargo run --example cli -- --provider zai --model glm-4.7
+//!   cargo run --example cli -- --provider ollama --model llama3.1:8b
 //!
-//! Run with LM Studio / Ollama / local OpenAI-compatible server:
+//! Run with LM Studio / local OpenAI-compatible server:
 //!   cargo run --example cli -- --api-url http://localhost:1234/v1 --model local-model
 //!
 //! Commands:
@@ -74,10 +75,11 @@ async fn main() {
         .and_then(|i| args.get(i + 1))
         .cloned();
 
-    let api_key = if api_url.is_some() {
+    let api_key_optional = api_url.is_some() || provider_name.as_deref() == Some("ollama");
+    let api_key = if api_key_optional {
         std::env::var("ANTHROPIC_API_KEY")
             .or_else(|_| std::env::var("API_KEY"))
-            .unwrap_or_default() // empty string OK for local
+            .unwrap_or_default() // empty string OK for local/Ollama
     } else {
         std::env::var("ANTHROPIC_API_KEY")
             .or_else(|_| std::env::var("API_KEY"))
@@ -92,6 +94,7 @@ async fn main() {
         Some("deepseek") => "deepseek-v4-flash",
         Some("mistral") => "mistral-large-latest",
         Some("minimax") => "MiniMax-Text-01",
+        Some("ollama") => "llama3.1:8b",
         Some("google") => "gemini-2.5-pro",
         _ => "claude-sonnet-4-20250514",
     };
@@ -118,7 +121,11 @@ async fn main() {
     };
 
     let mut agent = if let Some(ref url) = api_url {
-        Agent::new(OpenAiCompatProvider).with_model_config(ModelConfig::local(url, &model))
+        if provider_name.as_deref() == Some("ollama") {
+            Agent::new(OpenAiCompatProvider).with_model_config(ModelConfig::ollama(url, &model))
+        } else {
+            Agent::new(OpenAiCompatProvider).with_model_config(ModelConfig::local(url, &model))
+        }
     } else if let Some(ref prov) = provider_name {
         make_provider_agent(prov, &model)
     } else {
@@ -177,8 +184,13 @@ async fn main() {
             s if s.starts_with("/model ") => {
                 let new_model = s.trim_start_matches("/model ").trim();
                 agent = if let Some(ref url) = api_url {
-                    Agent::new(OpenAiCompatProvider)
-                        .with_model_config(ModelConfig::local(url, new_model))
+                    if provider_name.as_deref() == Some("ollama") {
+                        Agent::new(OpenAiCompatProvider)
+                            .with_model_config(ModelConfig::ollama(url, new_model))
+                    } else {
+                        Agent::new(OpenAiCompatProvider)
+                            .with_model_config(ModelConfig::local(url, new_model))
+                    }
                 } else if let Some(ref prov) = provider_name {
                     make_provider_agent(prov, new_model)
                 } else {
@@ -318,9 +330,11 @@ fn make_provider_agent(provider: &str, model: &str) -> Agent {
         "minimax" => {
             Agent::new(OpenAiCompatProvider).with_model_config(ModelConfig::minimax(model, model))
         }
+        "ollama" => Agent::new(OpenAiCompatProvider)
+            .with_model_config(ModelConfig::ollama("http://localhost:11434/v1", model)),
         "google" => Agent::new(GoogleProvider).with_model_config(ModelConfig::google(model, model)),
         other => {
-            eprintln!("Unknown provider: {other}. Supported: zai, openai, xai, groq, deepseek, mistral, minimax, google.");
+            eprintln!("Unknown provider: {other}. Supported: zai, openai, xai, groq, deepseek, mistral, minimax, ollama, google.");
             std::process::exit(1);
         }
     }

--- a/src/provider/model.rs
+++ b/src/provider/model.rs
@@ -91,6 +91,7 @@ pub struct OpenAiCompat {
     /// Tool results must include a `name` field.
     pub requires_tool_result_name: bool,
     /// Must insert an assistant message after tool results.
+    #[serde(default)]
     pub requires_assistant_after_tool_result: bool,
     /// How thinking/reasoning content is formatted in streaming.
     pub thinking_format: ThinkingFormat,
@@ -191,6 +192,14 @@ impl OpenAiCompat {
             ..Default::default()
         }
     }
+
+    /// Compat flags for Ollama's OpenAI-compatible API.
+    pub fn ollama() -> Self {
+        Self {
+            requires_assistant_after_tool_result: true,
+            ..Default::default()
+        }
+    }
 }
 
 /// Full model configuration. Knows everything needed to make API calls.
@@ -273,6 +282,26 @@ impl ModelConfig {
             cost: CostConfig::default(),
             headers: HashMap::new(),
             compat: Some(OpenAiCompat::default()),
+        }
+    }
+
+    /// Create a config for Ollama's OpenAI-compatible API.
+    ///
+    /// Default local base URL: `http://localhost:11434/v1`.
+    pub fn ollama(base_url: impl Into<String>, model_id: impl Into<String>) -> Self {
+        let id = model_id.into();
+        Self {
+            id: id.clone(),
+            name: id,
+            api: ApiProtocol::OpenAiCompletions,
+            provider: "ollama".into(),
+            base_url: base_url.into(),
+            reasoning: false,
+            context_window: 128_000,
+            max_tokens: 4096,
+            cost: CostConfig::default(),
+            headers: HashMap::new(),
+            compat: Some(OpenAiCompat::ollama()),
         }
     }
 
@@ -455,6 +484,49 @@ mod tests {
         let minimax = OpenAiCompat::minimax();
         assert!(minimax.supports_usage_in_streaming);
         assert!(!minimax.supports_store);
+
+        let ollama = OpenAiCompat::ollama();
+        assert!(ollama.requires_assistant_after_tool_result);
+        assert!(!ollama.requires_tool_result_name);
+    }
+
+    #[test]
+    fn test_openai_compat_deserializes_without_assistant_after_tool_result_flag() {
+        let compat: OpenAiCompat = serde_json::from_value(serde_json::json!({
+            "supports_store": false,
+            "supports_developer_role": false,
+            "supports_reasoning_effort": false,
+            "supports_thinking_control": false,
+            "supports_usage_in_streaming": true,
+            "max_tokens_field": "max_tokens",
+            "requires_tool_result_name": false,
+            "thinking_format": "open_ai"
+        }))
+        .unwrap();
+
+        assert!(!compat.requires_assistant_after_tool_result);
+    }
+
+    #[test]
+    fn test_model_config_local_remains_neutral() {
+        let config = ModelConfig::local("http://localhost:1234/v1", "local-model");
+        assert_eq!(config.api, ApiProtocol::OpenAiCompletions);
+        assert_eq!(config.provider, "local");
+        assert_eq!(config.base_url, "http://localhost:1234/v1");
+        let compat = config.compat.unwrap();
+        assert!(!compat.requires_assistant_after_tool_result);
+    }
+
+    #[test]
+    fn test_model_config_ollama() {
+        let config = ModelConfig::ollama("http://localhost:11434/v1", "llama3.1:8b");
+        assert_eq!(config.api, ApiProtocol::OpenAiCompletions);
+        assert_eq!(config.provider, "ollama");
+        assert_eq!(config.id, "llama3.1:8b");
+        assert_eq!(config.name, "llama3.1:8b");
+        assert_eq!(config.base_url, "http://localhost:11434/v1");
+        let compat = config.compat.unwrap();
+        assert!(compat.requires_assistant_after_tool_result);
     }
 
     #[test]

--- a/src/provider/openai_compat.rs
+++ b/src/provider/openai_compat.rs
@@ -261,6 +261,10 @@ fn build_request_body(
     }
 
     for msg in &config.messages {
+        if !matches!(msg, Message::ToolResult { .. } | Message::Assistant { .. }) {
+            maybe_insert_assistant_after_tool_results(&mut messages, compat);
+        }
+
         match msg {
             Message::User { content, .. } => {
                 messages.push(serde_json::json!({
@@ -336,6 +340,7 @@ fn build_request_body(
             }
         }
     }
+    maybe_insert_assistant_after_tool_results(&mut messages, compat);
 
     let max_tokens_val = config.max_tokens.unwrap_or(model_config.max_tokens);
     let mut body = serde_json::json!({
@@ -396,6 +401,27 @@ fn build_request_body(
     }
 
     body
+}
+
+fn maybe_insert_assistant_after_tool_results(
+    messages: &mut Vec<serde_json::Value>,
+    compat: &OpenAiCompat,
+) {
+    if !compat.requires_assistant_after_tool_result {
+        return;
+    }
+
+    let last_is_tool = messages
+        .last()
+        .and_then(|m| m.get("role"))
+        .and_then(|role| role.as_str())
+        == Some("tool");
+    if last_is_tool {
+        messages.push(serde_json::json!({
+            "role": "assistant",
+            "content": "",
+        }));
+    }
 }
 
 fn content_to_openai(content: &[Content]) -> serde_json::Value {
@@ -754,5 +780,153 @@ mod tests {
         let tool_msg = msgs.last().unwrap();
         // Text-only: content should be a plain string
         assert_eq!(tool_msg["content"], "hello");
+    }
+
+    #[test]
+    fn test_ollama_inserts_assistant_after_tool_result_run() {
+        let model_config = ModelConfig::ollama("http://localhost:11434/v1", "llama3.1:8b");
+        let compat = model_config.compat.as_ref().unwrap().clone();
+        let config = StreamConfig {
+            model: "llama3.1:8b".into(),
+            system_prompt: String::new(),
+            messages: vec![
+                Message::Assistant {
+                    content: vec![Content::ToolCall {
+                        provider_metadata: None,
+                        id: "call-1".into(),
+                        name: "bash".into(),
+                        arguments: serde_json::json!({"cmd": "ls"}),
+                    }],
+                    stop_reason: StopReason::ToolUse,
+                    model: "test".into(),
+                    provider: "test".into(),
+                    usage: Usage::default(),
+                    timestamp: 0,
+                    error_message: None,
+                },
+                Message::ToolResult {
+                    tool_call_id: "call-1".into(),
+                    tool_name: "bash".into(),
+                    content: vec![Content::Text {
+                        text: "a.txt\nb.txt".into(),
+                    }],
+                    is_error: false,
+                    timestamp: 0,
+                },
+                Message::User {
+                    content: vec![Content::Text {
+                        text: "which is largest?".into(),
+                    }],
+                    timestamp: 0,
+                },
+            ],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Off,
+            api_key: "test".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: Some(model_config.clone()),
+            cache_config: CacheConfig::default(),
+        };
+
+        let body = build_request_body(&config, &model_config, &compat);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs[0]["role"], "assistant");
+        assert_eq!(msgs[1]["role"], "tool");
+        assert_eq!(msgs[2]["role"], "assistant");
+        assert_eq!(msgs[2]["content"], "");
+        assert_eq!(msgs[3]["role"], "user");
+    }
+
+    #[test]
+    fn test_ollama_inserts_one_assistant_after_multiple_tool_results() {
+        let model_config = ModelConfig::ollama("http://localhost:11434/v1", "qwen2.5-coder:7b");
+        let compat = model_config.compat.as_ref().unwrap().clone();
+        let config = StreamConfig {
+            model: "qwen2.5-coder:7b".into(),
+            system_prompt: String::new(),
+            messages: vec![
+                Message::ToolResult {
+                    tool_call_id: "call-1".into(),
+                    tool_name: "read_file".into(),
+                    content: vec![Content::Text { text: "a".into() }],
+                    is_error: false,
+                    timestamp: 0,
+                },
+                Message::ToolResult {
+                    tool_call_id: "call-2".into(),
+                    tool_name: "read_file".into(),
+                    content: vec![Content::Text { text: "b".into() }],
+                    is_error: false,
+                    timestamp: 0,
+                },
+            ],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Off,
+            api_key: "test".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: Some(model_config.clone()),
+            cache_config: CacheConfig::default(),
+        };
+
+        let body = build_request_body(&config, &model_config, &compat);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "tool");
+        assert_eq!(msgs[1]["role"], "tool");
+        assert_eq!(msgs[2]["role"], "assistant");
+        assert_eq!(msgs[2]["content"], "");
+    }
+
+    #[test]
+    fn test_ollama_does_not_insert_assistant_before_existing_assistant() {
+        let model_config = ModelConfig::ollama("http://localhost:11434/v1", "llama3.1:8b");
+        let compat = model_config.compat.as_ref().unwrap().clone();
+        let config = StreamConfig {
+            model: "llama3.1:8b".into(),
+            system_prompt: String::new(),
+            messages: vec![
+                Message::ToolResult {
+                    tool_call_id: "call-1".into(),
+                    tool_name: "read_file".into(),
+                    content: vec![Content::Text { text: "a".into() }],
+                    is_error: false,
+                    timestamp: 0,
+                },
+                Message::Assistant {
+                    content: vec![Content::Text {
+                        text: "The file contains a.".into(),
+                    }],
+                    stop_reason: StopReason::Stop,
+                    model: "test".into(),
+                    provider: "test".into(),
+                    usage: Usage::default(),
+                    timestamp: 0,
+                    error_message: None,
+                },
+                Message::User {
+                    content: vec![Content::Text {
+                        text: "thanks".into(),
+                    }],
+                    timestamp: 0,
+                },
+            ],
+            tools: vec![],
+            thinking_level: ThinkingLevel::Off,
+            api_key: "test".into(),
+            max_tokens: None,
+            temperature: None,
+            model_config: Some(model_config.clone()),
+            cache_config: CacheConfig::default(),
+        };
+
+        let body = build_request_body(&config, &model_config, &compat);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "tool");
+        assert_eq!(msgs[1]["role"], "assistant");
+        assert_eq!(msgs[1]["content"][0]["text"], "The file contains a.");
+        assert_eq!(msgs[2]["role"], "user");
     }
 }


### PR DESCRIPTION
Closes #37.

## Summary

- Add first-class `ModelConfig::ollama(base_url, model_id)` support.
- Honor `OpenAiCompat::requires_assistant_after_tool_result` when serializing OpenAI-compatible tool result runs.
- Keep `ModelConfig::local(...)` neutral for LM Studio, llama.cpp, vLLM, and other compatible servers.
- Document Ollama alongside the other first-class model presets.

## Compatibility

- Existing serialized `OpenAiCompat` configs remain compatible because the new flag defaults to `false` during deserialization.
- Existing local OpenAI-compatible behavior is unchanged unless callers opt into the Ollama preset or flag.

## Validation

- `cargo fmt --check`
- `cargo test provider::model`
- `cargo test`
