### PR TITLE
Release 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `yoagent` to `0.8.2`.

## Included since 0.8.1

- Add first-class Ollama model preset support.
- Honor the Ollama assistant-after-tool-result compatibility flag.
- Keep existing local OpenAI-compatible configs backward-compatible.

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo test`
