### PR TITLE
Release 0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `yoagent` to `0.8.3`.

## Included since 0.8.2

- Add first-class Qwen / DashScope model preset support.
- Add `OpenAiCompat::qwen()` and `ModelConfig::openai_compat(...)` for local/custom model-family compatibility.
- Document hosted Qwen, regional DashScope URLs, local Qwen, and combined Qwen-on-Ollama compat.

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo test`
