### PR TITLE
Clarify DeepSeek prompt caching behavior

### DIFF
--- a/docs/concepts/prompt-caching.md
+++ b/docs/concepts/prompt-caching.md
@@ -12,6 +12,7 @@ In a multi-turn agent loop, each request sends the full context: system prompt +
 |----------|-------------|---------|-----------------|
 | **Anthropic** | Explicit (cache breakpoints) | 90% on hits | ✅ Auto-placed |
 | **OpenAI** | Automatic (>1024 tokens) | 50% on hits | None needed |
+| **DeepSeek** | Automatic prefix cache | Varies by model | None needed |
 | **Google Gemini** | Implicit (automatic) | Varies | None needed |
 | **Azure OpenAI** | Automatic (same as OpenAI) | 50% on hits | None needed |
 | **Amazon Bedrock** | Automatic (where supported) | Varies | None needed |
@@ -26,11 +27,19 @@ yoagent places up to 3 cache breakpoints automatically:
 
 This means on a typical multi-turn conversation, only the latest user message and the new assistant response cost full price.
 
+### DeepSeek
+
+DeepSeek's API manages context caching automatically. yoagent does not send
+Anthropic-style `cache_control` markers for DeepSeek; instead, keep stable
+prefixes stable (system prompt, tool definitions, and earlier messages) and
+monitor DeepSeek's `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`
+usage fields through `Usage.cache_read` and `Usage.input`.
+
 ## Configuration
 
 Caching is **enabled by default** with automatic breakpoint placement. No configuration needed for optimal behavior.
 
-### Disable Caching
+### Disable Explicit Cache Hints
 
 ```rust
 use yoagent::{CacheConfig, CacheStrategy};
@@ -41,6 +50,10 @@ let agent = Agent::new(provider)
         ..Default::default()
     });
 ```
+
+This disables yoagent-managed cache hints for providers such as Anthropic. It
+does not turn off automatic server-side caching for providers such as DeepSeek
+or OpenAI.
 
 ### Fine-Grained Control
 
@@ -69,7 +82,7 @@ println!("Cache hit rate: {:.1}%", usage.cache_hit_rate() * 100.0);
 ```
 
 - **`cache_read`** — tokens served from cache (cheap)
-- **`cache_write`** — tokens written to cache (slightly more than base price)
+- **`cache_write`** — tokens written to cache when the provider reports that metric
 - **`cache_hit_rate()`** — fraction of input tokens from cache (0.0–1.0)
 
 ## Cost Impact

--- a/docs/providers/openai-compat.md
+++ b/docs/providers/openai-compat.md
@@ -52,6 +52,11 @@ pub struct OpenAiCompat {
 
 `OpenAiCompat` presets are lower-level quirk flags. A provider is first-class when it also has a `ModelConfig::*` constructor; see [Model Presets](model-presets.md).
 
+DeepSeek context caching is automatic on DeepSeek's side. yoagent does not send
+`cache_control` markers for DeepSeek, but it does parse DeepSeek's
+`prompt_cache_hit_tokens` and `prompt_cache_miss_tokens` usage fields into
+`Usage.cache_read` and `Usage.input`.
+
 ## Adding a New Compatible Provider
 
 1. Add a constructor to `OpenAiCompat`:

--- a/src/provider/openai_compat.rs
+++ b/src/provider/openai_compat.rs
@@ -596,6 +596,7 @@ mod tests {
         assert!(body.get("max_completion_tokens").is_none());
         assert_eq!(body["thinking"]["type"], "disabled");
         assert!(body.get("reasoning_effort").is_none());
+        assert!(!body.to_string().contains("cache_control"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -200,10 +200,12 @@ impl Usage {
 // Cache configuration
 // ---------------------------------------------------------------------------
 
-/// Controls prompt caching behavior for providers that support it.
+/// Controls yoagent-managed prompt caching hints for providers that support
+/// explicit cache controls.
 ///
 /// By default, caching is enabled with automatic breakpoint placement.
-/// This gives optimal cost savings without any user configuration.
+/// Providers with automatic server-side caching, such as DeepSeek, may ignore
+/// this setting.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CacheConfig {
     /// Master switch — set to false to disable all caching hints.
@@ -254,7 +256,7 @@ pub enum CacheStrategy {
     /// Caches: system prompt, tool definitions, and recent conversation history.
     #[default]
     Auto,
-    /// Disable caching entirely.
+    /// Disable explicit cache hints.
     Disabled,
     /// Fine-grained control over what gets cached.
     Manual {


### PR DESCRIPTION
## Summary
- document that DeepSeek context caching is automatic and does not use cache_control markers
- clarify CacheConfig only controls explicit cache hints
- add a regression assertion for the DeepSeek OpenAI-compatible request shape

## Tests
- cargo fmt --check
- cargo test provider::openai_compat