### PR TITLE
release: 0.8.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoagent"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 description = "Simple, effective agent loop with tool execution and event streaming"
 license = "MIT"


### PR DESCRIPTION
Release v0.8.4.

## Changes
- feat: `SubAgentTool::with_skills` (#46) — attach a `SkillSet` to a sub-agent; its index is appended to the sub-agent's system prompt at dispatch time, mirroring `Agent::with_skills`. Closes #45.

Backward compatible (additive API). Version bumped in `Cargo.toml`; `cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)